### PR TITLE
Add indentation support

### DIFF
--- a/src/TimeTrace.cc
+++ b/src/TimeTrace.cc
@@ -332,7 +332,7 @@ TimeTrace::printInternal(std::vector<TimeTrace::Buffer*>* buffers, string* s, bo
             if (s->length() != 0) {
                 s->append("\n");
             }
-            snprintf(message, sizeof(message), "%8.1f ns (+%6.1f ns): ", ns,
+            snprintf(message, sizeof(message), "%9.1f ns (+%9.1f ns): ", ns,
                      ns - prevTime);
             s->append(message);
 #pragma GCC diagnostic push
@@ -359,7 +359,7 @@ TimeTrace::printInternal(std::vector<TimeTrace::Buffer*>* buffers, string* s, bo
                      event->arg1, event->arg2, event->arg3);
             }
 #pragma GCC diagnostic pop
-            fprintf(output, "%8.1f ns (+%6.1f ns): %s", ns, ns - prevTime,
+            fprintf(output, "%9.1f ns (+%9.1f ns): %s", ns, ns - prevTime,
                     message);
             fputc('\n', output);
         }

--- a/src/TimeTrace.h
+++ b/src/TimeTrace.h
@@ -50,6 +50,7 @@ class TimeTrace {
 
     static void setOutputFileName(const char* filename);
     static void print();
+    static void print_with_indent();
 
     /**
      * Record an event in a thread-local buffer, creating a new buffer
@@ -75,6 +76,8 @@ class TimeTrace {
      *      Argument to use when printing a message about this event.
      * \param arg3
      *      Argument to use when printing a message about this event.
+     *      when indentation is on, this argument is treated by the printer as 
+     *      the number of indentation.
      */
     static inline void record(uint64_t timestamp, const char* format,
                               uint32_t arg0 = 0, uint32_t arg1 = 0,
@@ -101,7 +104,7 @@ class TimeTrace {
     TimeTrace();
     static void createThreadBuffer();
     static void printInternal(std::vector<TimeTrace::Buffer*>* traces,
-                              std::string* s);
+                              std::string* s, bool ind=false);
 
     // Points to a private per-thread TimeTrace::Buffer object; NULL means
     // no such object has been created yet for the current thread.


### PR DESCRIPTION
This PR adds support for indentation in the logs. To not increase the cost of logging once, we simply treat the forth argument as the indentation level. Finally, use `print_with_indent()` to parse the forth argument as the indentation level and print each log line. 

Example code will be added to a new PR to `timetrace-ffi`.